### PR TITLE
#37 Saving a large project doesn't lock up Sublime

### DIFF
--- a/sublimerl_completion.py
+++ b/sublimerl_completion.py
@@ -209,9 +209,9 @@ class SublimErlCompletionsListener(sublime_plugin.EventListener):
 		class SublimErlThread(threading.Thread):
 			def run(self):
 				# compile
-				sublime.set_timeout(completions.compile_source, 0)
+				completions.compile_source(skip_deps=True)
 				# trigger event to reload completions
-				sublime.set_timeout(completions.generate_project_completions, 0)
+				completions.generate_project_completions()
 		SublimErlThread().start()
 
 	# CALLBACK ON VIEW LOADED

--- a/sublimerl_core.py
+++ b/sublimerl_core.py
@@ -252,9 +252,10 @@ class SublimErlProjectLoader():
 		env['PATH'] = "%s:%s:" % (env['PATH'], self.project_root)
 		return env
 
-	def compile_source(self):
+	def compile_source(self, skip_deps=False):
 		# compile to ebin
-		retcode, data = self.execute_os_command('%s compile' % SUBLIMERL.rebar_path, dir_type='project', block=True, log=False)
+		options = 'skip_deps=true' if skip_deps else ''
+		retcode, data = self.execute_os_command('%s compile %s' % (SUBLIMERL.rebar_path, options), dir_type='project', block=True, log=False)
 
 	def shellquote(self, s):
 		return SUBLIMERL.shellquote(s)


### PR DESCRIPTION
When saving a file, "rebar compile" is run with skip_deps=true so that dependencies aren't 
recompiled. On on_post_save, set_timout is not used as it locks up the GUI thread.
