### PR TITLE
Escape arbitrary values before substituting into re:compile

### DIFF
--- a/support/sublimerl_libparser.py
+++ b/support/sublimerl_libparser.py
@@ -283,7 +283,7 @@ class SublimErlLibParser():
 		current_params = []
 		lineno = 0
 		# get params
-		regex = re.compile(r"%s\((.*)\)\s*->" % fun[0], re.MULTILINE)
+		regex = re.compile(r"%s\((.*)\)\s*->" % re.escape(fun[0]), re.MULTILINE)
 		for m in regex.finditer(module):
 			params = m.groups()[0]
 			# strip out the eventual condition part ('when')


### PR DESCRIPTION
This fixes trying to compile e.g. ?MODULE, as ? is a regex special character
